### PR TITLE
PSA eBPF: Adding AssignRandomValue command

### DIFF
--- a/src/p4rrot/psa_ebpf/commands.py
+++ b/src/p4rrot/psa_ebpf/commands.py
@@ -1,0 +1,38 @@
+from p4rrot.known_types import KnownType
+from typing import Dict, List, Tuple
+from p4rrot.standard_fields import *
+from p4rrot.generator_tools import *
+from p4rrot.checks import *
+import random
+
+class AssignRandomValue(Command):
+
+    def __init__(self, vname, rngname, env=None):
+        self.env = env
+        self.vname=vname
+        self.rngname=rngname
+
+        
+        if self.env != None:
+            self.check()
+
+
+    def check(self):
+        var_exists(self.vname, self.env)
+        var_exists(self.rngname, self.env)
+        is_writeable(self.vname,self.env)
+        vars_have_the_same_type(self.vname, self.rngname, self.env)
+
+
+    def get_generated_code(self):
+        gc = GeneratedCode()
+        vi  = self.env.get_varinfo(self.vname)
+        gc.get_apply().writeln('{} = {}.read();'.format(vi['handle'], self.rngname))
+        return gc
+
+
+    def execute(self, test_env):
+        min_value = self.env.get_varinfo(self.rngname)['min_value']
+        max_value = self.env.get_varinfo(self.rngname)['max_value']
+        test_env[self.vname] = random.randint(target_type.cast_value(min_value),target_type.cast_value(max_value))
+

--- a/src/p4rrot/psa_ebpf/stateful.py
+++ b/src/p4rrot/psa_ebpf/stateful.py
@@ -1,0 +1,48 @@
+from p4rrot.known_types import KnownType
+from typing import Dict, List, Tuple
+from p4rrot.standard_fields import *
+from p4rrot.generator_tools import *
+
+class RandomNumberGenerator(SharedElement):
+    def __init__(self,vname:str, vtype:KnownType ,min_value=0,max_value=1,env=None) -> None:
+        self.vname = vname
+        self.vtype = vtype
+        self.min_value = min_value
+        self.max_value = max_value
+        self.env = env
+        self.properties = { 'min_value':self.min_value, 'max_value':self.max_value }
+
+        if self.env!=None:
+            self.check()
+
+    def check(self):
+        assert self.vtype in [ uint8_t, uint16_t ,uint32_t, uint64_t ], 'Not supported random generation'
+
+    
+    def get_name(self):
+        return self.vname
+
+
+    def get_type(self):
+        return self.vtype
+
+    
+    def get_properties(self):
+        return self.properties
+
+
+    def get_generated_code(self):
+        gc = GeneratedCode()
+        gc.get_decl().writeln('Random< {} >(({}){},({}){}) {};'.format(
+            self.vtype.get_p4_type(), 
+            self.vtype.get_p4_type(), 
+            self.vtype.to_p4_literal(self.min_value), 
+            self.vtype.get_p4_type(), 
+            self.vtype.to_p4_literal(self.max_value),
+            self.vname)
+            )
+        return gc
+
+    def execute(self,test_env):
+        target_type = self.env.get_varinfo(self.vname)['type']
+        test_env[self.vname] = random.randint(target_type.cast_value(self.min_value),target_type.cast_value(self.max_value))


### PR DESCRIPTION
Adds the AssignRandomValue command. To get a
random value in the PSA architecture you need
to instatiate a random value generator in the
a_declarations section. This is achieved by
declaring it as a state variable. To get a random
value only the variable and the name of the random number genrator need to be supplied to the
AssignRandomValue constructor. This will end up to call the read method of the rng.