### PR TITLE
PSA eBPF: GetTimestamp

### DIFF
--- a/src/p4rrot/psa_ebpf/commands.py
+++ b/src/p4rrot/psa_ebpf/commands.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 from p4rrot.standard_fields import *
 from p4rrot.generator_tools import *
 from p4rrot.checks import *
+from p4rrot.psa_ebpf.known_types import * 
 import random
 
 class AssignRandomValue(Command):
@@ -59,3 +60,29 @@ class AssignHash(Command):
         source = self.env.get_varinfo(self.s_name)
         gc.get_apply().writeln('{} = {}.get_hash({});'.format(target['handle'], self.hash_name, source['handle']))
         return gc
+
+
+class GetTimestamp(Command):
+    def __init__(self, vname, env=None):
+        self.env = env
+        self.vname = vname
+
+        if self.env != None:
+            self.check()
+
+    
+    def check(self):
+        var_exists(self.vname, self.env)
+        assert self.env.get_varinfo(self.vname)['type'] == timestamp_t
+        is_writeable(self.vname, self.env)
+
+
+    def get_generated_code(self):
+        gc = GeneratedCode()
+        vi = self.env.get_varinfo(self.vname)
+        gc.get_apply().writeln('{} = istd.ingress_timestamp;'.format(vi['handle']))
+        return gc
+
+    
+    def execute(self, test_env):
+        pass

--- a/src/p4rrot/psa_ebpf/known_types.py
+++ b/src/p4rrot/psa_ebpf/known_types.py
@@ -1,0 +1,17 @@
+from p4rrot.known_types import *  
+
+class timestamp_t(KnownType):
+
+    def get_p4_type() -> str:
+        return 'Timestamp_t'
+
+    def get_size() -> int:
+        return 8
+
+    def to_p4_literal(v):
+        return str(timestamp_t.cast_value(v))
+    
+    def cast_value(v):
+        if type(v)==int:
+            return ctypes.c_uint64(v).value
+        raise Exception('Can not recognize value {}'.format(v))  


### PR DESCRIPTION
Adding GetTimestamp command. According to PSA specification the width of the Timestamp_t data type is dependent on the implementation. In case of ebpf this is a u64. Defined in psa.h A new data type is added to P4rrot because otherwise the p4c compiler complains.